### PR TITLE
Allow trailing commas in regex expression

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,5 +28,5 @@ repos:
   rev: v1.2.0
   hooks:
     - id: mypy
-      args: [--allow-redefinition]
+      args: [--allow-redefinition, --ignore-missing-imports]
       exclude: ^examples/

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - pre-commit
   - referencing
   - jsonschema
+  - python-rapidjson
   - transformers
   - pip
   - pip:


### PR DESCRIPTION
In reference to: https://discord.com/channels/1182316225284554793/1182592312669372427/1236204036945084480
 
Correct me if I'm wrong, but...

I think this piece of code is the way it is because `json.loads` is strict about the format of its input string. This forces us to also be strict when building the regex from the json schema.

This isn't a problem when all of the keys are required. Something like `",".join(f'\"{key}\": to_regex(value)' for key, value in properties.items())` would suffice. Nor when at least one key is required. In which case, we can use it as some sort of an anchor and insert the commas before and after it. But when _all_ of the keys are optional, we have to do this O(K^2) brute force approach where we try all of the keys as possible anchors.

If we use `python-rapidjson`'s `rapidjson.loads(..., parse_mode=PM_TRAILING_COMMAS)` instead, we would not only speed up parsing but also free ourselves from worrying about trailing commas. With this, something like `"".join(f'(\"{key}\": to_regex(value),)?' for key, value in properties.items())` would suffice.
